### PR TITLE
Renamed the local variable 'value_rpm' to follow naming convention.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ captures/
 /out/
 
 # User-specific configurations
+.idea/*
 .idea/.name
 .idea/caches/
 .idea/compiler.xml

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ captures/
 /out/
 
 # User-specific configurations
-.idea/*
+.idea/sonarlint
 .idea/.name
 .idea/caches/
 .idea/compiler.xml

--- a/src/main/java/de/dennisguse/opentracks/data/models/Cadence.java
+++ b/src/main/java/de/dennisguse/opentracks/data/models/Cadence.java
@@ -2,7 +2,7 @@ package de.dennisguse.opentracks.data.models;
 
 import java.time.Duration;
 
-public record Cadence(float value_rpm) {
+public record Cadence(float valueRPM) {
 
     public static Cadence of(float value, Duration duration) {
         if (duration.isZero()) {
@@ -12,8 +12,8 @@ public record Cadence(float value_rpm) {
         return new Cadence(value / (duration.toMillis() / (float) Duration.ofMinutes(1).toMillis()));
     }
 
-    public static Cadence of(float value_rpm) {
-        return new Cadence(value_rpm);
+    public static Cadence of(float valueRPM) {
+        return new Cadence(valueRPM);
     }
 
     public static Cadence zero() {
@@ -21,6 +21,6 @@ public record Cadence(float value_rpm) {
     }
 
     public float getRPM() {
-        return value_rpm;
+        return valueRPM;
     }
 }


### PR DESCRIPTION
## Description
Renamed the local variable 'value_rpm' to follow variable naming convention guidelines. Variable should follow camel case naming convention (Where every word except the first word of the variable name starts with uppercase letter). Used 'valueRPM' name for the variable adhering to the camel case convention.

## What problem it solves?
* Improves code quality.
* Reduces the Technical debt.

