### PR TITLE
Added private constructor to hide the implicit public one

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/models/ActivityIcon.java
+++ b/src/main/java/de/dennisguse/opentracks/data/models/ActivityIcon.java
@@ -5,5 +5,7 @@ import de.dennisguse.opentracks.R;
 public class ActivityIcon {
 
     static final int ICON_UNKNOWN = R.drawable.ic_logo_24dp;
-
+    private ActivityIcon(){
+        // Private constructor to prevent instantiation of the class
+    };
 }


### PR DESCRIPTION
Implemented a private constructor with no arguments that prevents object instantiation.

**What problem it solves?**

- Enhanced Code Quality
- Eliminate potential security risk
- Reduced Technical Debt